### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Customer Management [![Build Status](https://api.travis-ci.com/apache/fineract-cn-customer.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-customer) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-customer)](https://hub.docker.com/r/apache/fineract-cn-customer/builds)
+# Apache Fineract CN Customer Management [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-customer)](https://hub.docker.com/r/apache/fineract-cn-customer/builds)
 
 This service covers simple functionality around CRM and KYC. [Read more](https://cwiki.apache.org/confluence/display/FINERACT/Fineract+CN+Project+Structure#FineractCNProjectStructure-customer).
 


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.